### PR TITLE
fix: HeaderGlobal에 "use client" 지시어 추가

### DIFF
--- a/src/components/layout/HeaderGlobal.js
+++ b/src/components/layout/HeaderGlobal.js
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState } from 'react';
 import Link from 'next/link';
 


### PR DESCRIPTION
- HeaderGlobal.js를 클라이언트 컴포넌트로 지정하여 Next.js 앱 라우터 환경에서의 React Hook 오류를 해결했어요.